### PR TITLE
Disable inference cache when EGF is used

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -738,6 +738,8 @@ def predict(
     }
     diffusion_params = BoltzDiffusionParams()
     diffusion_params.step_scale = step_scale
+    if use_egf:
+        diffusion_params.use_inference_model_cache = False
 
     pairformer_args = PairformerArgs(use_trifast=(accelerator != "cpu"))
     msa_module_args = MSAModuleArgs(use_trifast=(accelerator != "cpu"))


### PR DESCRIPTION
## Summary
- avoid activation errors during EGF runs by disabling the inference model cache

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytorch_lightning')*

------
https://chatgpt.com/codex/tasks/task_e_68407625e20083269ed66b978f933ca1