### PR TITLE
Fix inference crash with checkpointed layers

### DIFF
--- a/src/boltz/model/modules/transformers.py
+++ b/src/boltz/model/modules/transformers.py
@@ -126,8 +126,9 @@ class DiffusionTransformer(Module):
         dim_single_cond = default(dim_single_cond, dim)
 
         self.layers = ModuleList()
+        use_ckpt = activation_checkpointing and torch.is_grad_enabled() and not getattr(torch, "is_inference_mode_enabled", lambda: False)()
         for _ in range(depth):
-            if activation_checkpointing:
+            if use_ckpt:
                 self.layers.append(
                     checkpoint_wrapper(
                         DiffusionTransformerLayer(

--- a/src/boltz/model/modules/trunk.py
+++ b/src/boltz/model/modules/trunk.py
@@ -173,8 +173,9 @@ class MSAModule(nn.Module):
             bias=False,
         )
         self.layers = nn.ModuleList()
+        use_ckpt = activation_checkpointing and torch.is_grad_enabled() and not getattr(torch, "is_inference_mode_enabled", lambda: False)()
         for i in range(msa_blocks):
-            if activation_checkpointing:
+            if use_ckpt:
                 self.layers.append(
                     checkpoint_wrapper(
                         MSALayer(
@@ -468,8 +469,9 @@ class PairformerModule(nn.Module):
         self.num_heads = num_heads
 
         self.layers = nn.ModuleList()
+        use_ckpt = activation_checkpointing and torch.is_grad_enabled() and not getattr(torch, "is_inference_mode_enabled", lambda: False)()
         for i in range(num_blocks):
-            if activation_checkpointing:
+            if use_ckpt:
                 self.layers.append(
                     checkpoint_wrapper(
                         PairformerLayer(


### PR DESCRIPTION
## Summary
- avoid checkpoint wrappers when gradients are disabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytorch_lightning')*

------
https://chatgpt.com/codex/tasks/task_e_684078e02fb88326a499cf8af6d5b12a