### PR TITLE
Fix torch undefined bug

### DIFF
--- a/src/boltz/model/modules/transformers.py
+++ b/src/boltz/model/modules/transformers.py
@@ -1,6 +1,7 @@
 # started from code from https://github.com/lucidrains/alphafold3-pytorch, MIT License, Copyright (c) 2024 Phil Wang
 
 from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper
+import torch
 from torch import nn, sigmoid
 from torch.nn import (
     LayerNorm,


### PR DESCRIPTION
## Summary
- import `torch` in `transformers.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pytorch_lightning, torch, requests)*

------
https://chatgpt.com/codex/tasks/task_e_68407bad91bc8326b5932bfe53c8da0e